### PR TITLE
Explicit py4j version as in Spark Python libs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,6 @@ setup(name='pyspark',
     description='PySpark python package',
     long_description='Library provides high-level APIs in Python and an optimized engine that supports general computation graphs for data analysis.',
     install_requires=[
-        'py4j'
+        'py4j=0.9'
     ],
     packages=find_packages())


### PR DESCRIPTION
Current py4j version is 0.10.2 and has changed classes signatures, conflicting with pyspark 1.6.1 code.